### PR TITLE
Allow more locations for buildpack scripts

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,4 +34,4 @@ Phil Hagelberg originated this lovely idea.
     $ git push heroku master
     ...
 
-[buildpack]: http://devcenter.heroku.com/articles/buildpack
+[buildpack]: https://devcenter.heroku.com/articles/buildpack-api#buildpack-api

--- a/Readme.md
+++ b/Readme.md
@@ -4,10 +4,8 @@ This is a [Heroku buildpack][buildpack] for Heroku apps that
 wish to build themselves.
 
 It expects the app to provide the usual buildpack executables
-in its source tree, in a directory named "bin" in the top of
-the git repo; this is the same interface all other buildpacks
-provide. See the [buildpack documentation][buildpack] for more
-details about this interface.
+in its source tree, according to the
+[buildpack documentation][buildpack].
 
 Thus, an app serves as its own buildpack.
 
@@ -15,23 +13,51 @@ Phil Hagelberg originated this lovely idea.
 
 ## Usage
 
-    $ find . -type f -print
-    ./bin/compile
-    ./bin/detect
-    ./bin/release
-    ./bin/run
-    ./Procfile
+1. Put the `detect`, `compile`, and `release` scripts in one
+   of the directories mentioned below.
 
-    $ cat Procfile
-    work: bin/run
+1. `heroku buildpacks:add -i 1 heroku-community/inline`
 
-    $ heroku create
-    ...
+1. Deploy as usual
 
-    $ heroku buildpacks:add -i 1 heroku-community/inline
-    ...
+### Option 1: In `bin/` directory
 
-    $ git push heroku master
-    ...
+The app should put the buildpack executables in the top-level
+`bin/` directory, exactly the same as a normal buildpack.
+
+```
+./bin/compile
+./bin/detect
+./bin/release
+./Procfile
+<rest of your app>
+```
+
+### Option 2: In `.heroku/buildpack/` directory
+
+```
+./.heroku/buildpack/compile
+./.heroku/buildpack/detect
+./.heroku/buildpack/release
+./Procfile
+<rest of your app>
+```
+
+### Option 3: In a directory specified in `.heroku-buildpack-dir`
+
+```
+./.heroku-buildpack-dir
+./my/custom/path/compile
+./my/custom/path/detect
+./my/custom/path/release
+./Procfile
+<rest of your app>
+```
+
+where `.heroku-buildpack-dir` contains a single line:
+
+```
+my/custom/path
+```
 
 [buildpack]: https://devcenter.heroku.com/articles/buildpack-api#buildpack-api

--- a/bin/compile
+++ b/bin/compile
@@ -1,3 +1,7 @@
 #!/bin/sh
 # Usage: bin/compile <build-dir> <cache-dir> <env-dir>
-exec "$1"/bin/compile "$@"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILDPACK_DIR="$("${HERE}/../lib/find_buildpack_dir.sh" "$1")"
+
+exec "${BUILDPACK_DIR}/compile" "$@"

--- a/bin/detect
+++ b/bin/detect
@@ -1,3 +1,7 @@
 #!/bin/sh
 # Usage: bin/detect <build-dir>
-exec "$1"/bin/detect "$@"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILDPACK_DIR="$("${HERE}/../lib/find_buildpack_dir.sh" "$1")"
+
+exec "${BUILDPACK_DIR}/detect" "$@"

--- a/bin/release
+++ b/bin/release
@@ -1,3 +1,7 @@
 #!/bin/sh
 # Usage: bin/release <build-dir>
-exec "$1"/bin/release "$@"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILDPACK_DIR="$("${HERE}/../lib/find_buildpack_dir.sh" "$1")"
+
+exec "${BUILDPACK_DIR}/release" "$@"

--- a/lib/find_buildpack_dir.sh
+++ b/lib/find_buildpack_dir.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -eu -o pipefail
+
+BUILD_DIR="${1?}"
+
+if [[ -f "${BUILD_DIR}/.heroku-buildpack-dir" ]]; then
+    BUILDPACK_DIR="$(cat "${BUILD_DIR}/.heroku-buildpack-dir")"
+elif [[ -d "${BUILD_DIR}/.heroku/buildpack" ]]; then
+    BUILDPACK_DIR="${BUILD_DIR}/.heroku/buildpack"
+else
+    BUILDPACK_DIR="${BUILD_DIR}/bin"
+fi
+
+echo "${BUILDPACK_DIR}"


### PR DESCRIPTION
I actually use `bin/` for my normal code, and it'd be nice to namespace these scripts so it's obvious they're for heroku. So I also allow `.heroku/buildpack/...` as a possible directory. But to be even more extensible, someone could provide a `.heroku-buildpack-dir` file that specifies another directory, possibly if the user has a monorepo and wants to put heroku scripts at `my-app/.heroku/buildpack/...`