### PR TITLE
Make `bin/release` optional

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,3 +1,9 @@
 #!/bin/sh
 # Usage: bin/release <build-dir>
-exec "$1"/bin/release "$@"
+
+RELEASE_SCRIPT="${1}/bin/release"
+
+# The Buildpack API states that the `bin/release` script is optional.
+if [ -f "${RELEASE_SCRIPT}" ]; then
+    exec "${RELEASE_SCRIPT}" "$@"
+fi


### PR DESCRIPTION
Since the Buildpack API states that the `bin/release` script is optional:
https://devcenter.heroku.com/articles/buildpack-api#bin-release

Previously if the file wasn't provided, the inline buildpack would exit 1 during `bin/release` -- which at the moment doesn't result in a failed build (as Codon ignores such failures due to an oversight).

By fixing this, we reduce the number of cases that may be broken should we decide to fix the issue in Codon in the future.

Closes #3.
GUS-W-11256291. 