### PR TITLE
Clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Phil Hagelberg originated this lovely idea.
     $ find . -type f -print
     ./bin/compile
     ./bin/detect
-    ./bin/release
     ./bin/run
     ./Procfile
 
@@ -34,4 +33,4 @@ Phil Hagelberg originated this lovely idea.
     $ git push heroku master
     ...
 
-[buildpack]: http://devcenter.heroku.com/articles/buildpack
+[buildpack]: https://devcenter.heroku.com/articles/buildpacks


### PR DESCRIPTION
- Correct filename capitalisation (`Readme.md` -> `README.md`)
- Fix non-canonical Dev Center buildpacks link
- Remove `bin/release` file mention since it's now optional

GUS-W-23426985.